### PR TITLE
fix: initialize t0 timer before HTTP request in tavily_search

### DIFF
--- a/backend/services/tool_gateway/direct_tools/tavily_search.py
+++ b/backend/services/tool_gateway/direct_tools/tavily_search.py
@@ -94,6 +94,7 @@ def tavily_search(
     if include_domains:
         body["include_domains"] = include_domains[:50]  # API limit
 
+    t0 = time.perf_counter()
     req = urllib.request.Request(
         TAVILY_SEARCH_URL,
         data=json.dumps(body).encode("utf-8"),


### PR DESCRIPTION
## Summary
- `t0` variable was referenced in 3 places in `tavily_search.py` (lines 113, 134, 143) for latency tracking but was never initialized
- This caused a `NameError: name 't0' is not defined` crash in diagnostics recording whenever a Tavily API call succeeded or failed
- Added `t0 = time.perf_counter()` immediately before the HTTP request

## Test plan
- [x] 76 unit tests pass (`pytest -m "not external" -v`)
- [x] No external API calls required to verify fix
- [ ] Manual smoke test: run an assessment that triggers Tavily search

🤖 Generated with [Claude Code](https://claude.com/claude-code)