### PR TITLE
fix(config): remove isdir check from get_project_dir for deploy portability

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -27,8 +27,16 @@ def reload_env() -> None:
 
 
 def get_project_dir() -> str | None:
+    """
+    Return the configured project directory path.
+    The path does NOT need to exist locally — it is used as a stable string
+    for namespace hashing in Pinecone. This allows deployed environments
+    (e.g. Render) to share the same namespace as the seeding machine without
+    requiring the physical directory to be present.
+    Seeding operations validate directory existence separately.
+    See: https://github.com/Anoop-Viswan/AI-Powered-Cloud-Migration-Command-Center/issues/5
+    """
     path = os.getenv("PINECONE_PROJECT_DIR")
     if not path:
         return None
-    path = os.path.abspath(os.path.expanduser(path))
-    return path if os.path.isdir(path) else None
+    return os.path.abspath(os.path.expanduser(path))


### PR DESCRIPTION
## Summary
- Removes `os.path.isdir()` validation from `get_project_dir()` in `backend/config.py`
- `PINECONE_PROJECT_DIR` is used as a string key for Pinecone namespace hashing — it doesn't need to physically exist on the deployment server
- Fixes zero KB hits on Render while local search worked correctly

## Root Cause
`get_project_dir()` returned `None` when the path didn't exist on the filesystem. On Render, the Mac path `/Users/anoopviswan/...` doesn't exist → `None` → wrong namespace → 0 Pinecone hits → fallback to Tavily only.

## Test Plan
- [x] 76/76 tests passing (`pytest -m "not external"`)
- [x] Local KB search still returns correct results
- [ ] Render redeploy — verify `project_dir_configured: true` in `/api/health`
- [ ] Render KB search — verify confidence > 0.35 on FinanceHub query

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)