### PR TITLE
fix: security patches for CVE-2026-45134 and CVE-2026-41305

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@vitejs/plugin-react": "^6.0.1",
         "autoprefixer": "^10.4.17",
-        "postcss": "^8.5.9",
+        "postcss": "^8.5.11",
         "tailwindcss": "^3.4.1",
         "vite": "^8.0.8"
       }
@@ -1383,9 +1383,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@vitejs/plugin-react": "^6.0.1",
     "autoprefixer": "^10.4.17",
-    "postcss": "^8.5.9",
+    "postcss": "^8.5.11",
     "tailwindcss": "^3.4.1",
     "vite": "^8.0.8"
   }

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ langgraph==1.1.6
 langchain-openai==1.2.1
 langchain-core==1.3.3
 langchain-anthropic==1.4.1
-langsmith==0.7.31
+langsmith==0.8.0


### PR DESCRIPTION
## Security Patches

Fix two CVEs identified in Dependabot alerts:

### CVE-2026-45134 (langsmith)
- **Severity:** HIGH (but low-risk for this app)
- **Issue:** Unsafe deserialization of untrusted prompt manifests
- **Fix:** langsmith 0.7.31 → 0.8.0
- **Why safe for us:** We only use langsmith for tracing, never pull public prompts

### CVE-2026-41305 (postcss)
- **Severity:** MEDIUM
- **Issue:** XSS via unescaped `</style>` in CSS stringify output
- **Fix:** postcss 8.5.9 → 8.5.11
- **Why safe for us:** CSS comes from Tailwind config, not user input

Both upgrades are within safe version ranges and follow defense-in-depth security practices.