### PR TITLE
fix(security): path injection + stack trace exposure (CodeQL)

### DIFF
--- a/backend/routers/assessment.py
+++ b/backend/routers/assessment.py
@@ -4,6 +4,7 @@ import json
 import re
 import queue
 import threading
+import uuid
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
@@ -62,6 +63,15 @@ def _user_friendly_error_detail(exc: Exception) -> str:
 def _uploads_dir() -> Path:
     root = Path(__file__).resolve().parent.parent.parent
     return root / "data" / "assessment_uploads"
+
+
+def _validate_assessment_id(assessment_id: str) -> None:
+    """assessment_id is always a server-generated UUID (see store.create()); reject anything else
+    before it's used to build a filesystem path, to prevent path traversal."""
+    try:
+        uuid.UUID(assessment_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid assessment_id")
 
 
 def get_store() -> AssessmentStore:
@@ -187,6 +197,7 @@ async def upload_diagram(
     store: AssessmentStore = Depends(get_store),
 ):
     """Upload architecture diagram (current or future state). Returns path to store in profile."""
+    _validate_assessment_id(assessment_id)
     if diagram_type not in ALLOWED_DIAGRAM_TYPES:
         raise HTTPException(status_code=400, detail="type must be 'current' or 'future'")
     if not store.get(assessment_id):
@@ -208,6 +219,7 @@ async def upload_diagram(
 @router.get("/assessment/{assessment_id}/diagram/{diagram_type}")
 def get_diagram(assessment_id: str, diagram_type: str):
     """Serve uploaded architecture diagram (current or future)."""
+    _validate_assessment_id(assessment_id)
     if diagram_type not in ALLOWED_DIAGRAM_TYPES:
         raise HTTPException(status_code=404, detail="Not found")
     from fastapi.responses import FileResponse
@@ -225,6 +237,7 @@ def get_target_diagram(
     format: str = Query("png", description="png (image) or mmd (editable Mermaid source)"),
 ):
     """Serve generated target-state architecture diagram: PNG image or editable .mmd file. Generated when you run Generate report."""
+    _validate_assessment_id(assessment_id)
     from fastapi.responses import FileResponse
     dir_path = _target_diagram_dir(assessment_id)
     if format and format.lower() == "mmd":

--- a/backend/services/assessment/diagram_export.py
+++ b/backend/services/assessment/diagram_export.py
@@ -14,6 +14,7 @@ import base64
 import logging
 import ssl
 import urllib.request
+import uuid
 from pathlib import Path
 
 import certifi
@@ -24,8 +25,15 @@ logger = logging.getLogger(__name__)
 MERMAID_INK_IMG = "https://mermaid.ink/img"
 
 
+def _validate_assessment_id(assessment_id: str) -> None:
+    """assessment_id is always a server-generated UUID (see store.create()); reject anything else
+    before it's used to build a filesystem path, to prevent path traversal."""
+    uuid.UUID(assessment_id)
+
+
 def _diagrams_dir(assessment_id: str) -> Path:
     """Directory for generated diagram artifacts: .mmd and .png."""
+    _validate_assessment_id(assessment_id)
     root = Path(__file__).resolve().parent.parent.parent.parent
     d = root / "data" / "assessment_diagrams" / assessment_id
     d.mkdir(parents=True, exist_ok=True)
@@ -34,6 +42,7 @@ def _diagrams_dir(assessment_id: str) -> Path:
 
 def clear_diagram_artifacts(assessment_id: str) -> None:
     """Remove generated diagram folder for this assessment (e.g. when re-running research)."""
+    _validate_assessment_id(assessment_id)
     root = Path(__file__).resolve().parent.parent.parent.parent
     d = root / "data" / "assessment_diagrams" / assessment_id
     if d.exists():

--- a/backend/services/assessment/report_docx.py
+++ b/backend/services/assessment/report_docx.py
@@ -1,6 +1,7 @@
 """Convert assessment report (markdown or plain text) to DOCX for download."""
 
 import re
+import uuid
 from io import BytesIO
 from pathlib import Path
 
@@ -11,6 +12,10 @@ from docx.enum.text import WD_ALIGN_PARAGRAPH
 
 def _diagram_png_path(assessment_id: str) -> Path | None:
     """Path to generated target architecture PNG, if it exists."""
+    try:
+        uuid.UUID(assessment_id)
+    except ValueError:
+        return None
     root = Path(__file__).resolve().parent.parent.parent.parent
     p = root / "data" / "assessment_diagrams" / assessment_id / "target_architecture.png"
     return p if p.exists() else None

--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -1,7 +1,10 @@
 """LLM service: summarize search results into an answer. Uses LLM provider abstraction (OpenAI, Anthropic, Azure)."""
+import logging
 import os
 
 from langchain_core.messages import HumanMessage, SystemMessage
+
+logger = logging.getLogger(__name__)
 
 from backend.services.diagnostics.recorder import invoke_llm
 from backend.services.llm_provider import get_llm
@@ -51,5 +54,6 @@ def summarize_with_llm(
         ]
         response = invoke_llm(llm, messages, "chat", assessment_id=None)
         return response.content if hasattr(response, "content") else str(response) or "No response generated."
-    except Exception as e:
-        return f"LLM error: {str(e)}"
+    except Exception:
+        logger.exception("LLM call failed during summarize_with_llm")
+        return "LLM error: the request could not be completed. Check server logs for details."


### PR DESCRIPTION
## Summary
Fixes all 15 open CodeQL alerts (14x `py/path-injection`, 1x `py/stack-trace-exposure`), open since 2026-04-06.

- `assessment_id` is always a server-generated UUID (`store.create()`), but was used to build filesystem paths in `assessment.py`, `diagram_export.py`, and `report_docx.py` without validation. `get_diagram` / `get_target_diagram` didn't even check the store first — a crafted `assessment_id` could traverse outside the intended data dir.
- Added `_validate_assessment_id()` (parses as `uuid.UUID`, 400s on failure) at every flagged call site.
- `backend/services/llm.py`: `summarize_with_llm` returned raw `str(exception)` straight to the API client. Now logs the full exception server-side and returns a generic message.

## Test plan
- [x] `PYTHONPATH=. pytest tests/ -v` — 80 passed, 1 pre-existing failure (`test_mermaid_ink_reachable`, external network 403, unrelated to this change)
- [x] Manually traced every flagged file:line back to its taint source to confirm this closes it