### PR TITLE
fix(ci): dedupe daily security scan issues

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -124,11 +124,18 @@ jobs:
             --description "Security vulnerability or scan finding" \
             --force 2>/dev/null || true
 
-          gh issue create \
-            --title "[SECURITY] Daily scan findings — ${SCAN_DATE}" \
-            --body "$(printf '%b' "$BODY")" \
-            --label "security" \
-            --assignee "Anoop-Viswan"
+          # Reuse the existing open tracking issue instead of spawning a new one every day.
+          EXISTING=$(gh issue list --label "security" --state open --search "in:title \"[SECURITY] Daily scan findings\"" --json number --jq '.[0].number')
+
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body "$(printf '%b' "$BODY")"
+          else
+            gh issue create \
+              --title "[SECURITY] Daily scan findings" \
+              --body "$(printf '%b' "$BODY")" \
+              --label "security" \
+              --assignee "Anoop-Viswan"
+          fi
 
       - name: Fail job if any scanner found findings
         if: env.PIP_AUDIT_FAILED == 'true' || env.BANDIT_FAILED == 'true' || env.NPM_AUDIT_FAILED == 'true'


### PR DESCRIPTION
## Summary
The Daily Security Scan workflow creates a GitHub Issue every time a scanner finds something — but it always created a **new** issue with the date in the title, instead of updating one. Result: 21 duplicate open issues (#104-124) piled up since 2026-06-13, one per day the scan failed.

Now it searches for an existing open issue titled `[SECURITY] Daily scan findings` with the `security` label and comments on it with the day's findings; only creates a new issue if none exists.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML valid
- [ ] Anoop to trigger `workflow_dispatch` after merge to confirm it comments on the consolidated issue instead of creating a new one (this was already on the TODO list from last session)