### PR TITLE
fix(security): regex sanitizer pattern so CodeQL actually clears path-injection alerts

### DIFF
--- a/backend/routers/assessment.py
+++ b/backend/routers/assessment.py
@@ -4,7 +4,6 @@ import json
 import re
 import queue
 import threading
-import uuid
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
@@ -65,12 +64,13 @@ def _uploads_dir() -> Path:
     return root / "data" / "assessment_uploads"
 
 
+_UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
+
 def _validate_assessment_id(assessment_id: str) -> None:
     """assessment_id is always a server-generated UUID (see store.create()); reject anything else
     before it's used to build a filesystem path, to prevent path traversal."""
-    try:
-        uuid.UUID(assessment_id)
-    except ValueError:
+    if not _UUID_RE.match(assessment_id):
         raise HTTPException(status_code=400, detail="Invalid assessment_id")
 
 

--- a/backend/services/assessment/diagram_export.py
+++ b/backend/services/assessment/diagram_export.py
@@ -12,9 +12,9 @@ References: https://mermaid.ink (render Mermaid to image via URL).
 
 import base64
 import logging
+import re
 import ssl
 import urllib.request
-import uuid
 from pathlib import Path
 
 import certifi
@@ -24,11 +24,14 @@ logger = logging.getLogger(__name__)
 # Base URL for mermaid.ink image rendering (no auth required)
 MERMAID_INK_IMG = "https://mermaid.ink/img"
 
+_UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 
 def _validate_assessment_id(assessment_id: str) -> None:
     """assessment_id is always a server-generated UUID (see store.create()); reject anything else
     before it's used to build a filesystem path, to prevent path traversal."""
-    uuid.UUID(assessment_id)
+    if not _UUID_RE.match(assessment_id):
+        raise ValueError(f"Invalid assessment_id: {assessment_id!r}")
 
 
 def _diagrams_dir(assessment_id: str) -> Path:

--- a/backend/services/assessment/report_docx.py
+++ b/backend/services/assessment/report_docx.py
@@ -1,7 +1,6 @@
 """Convert assessment report (markdown or plain text) to DOCX for download."""
 
 import re
-import uuid
 from io import BytesIO
 from pathlib import Path
 
@@ -9,12 +8,12 @@ from docx import Document
 from docx.shared import Pt, Inches
 from docx.enum.text import WD_ALIGN_PARAGRAPH
 
+_UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
 
 def _diagram_png_path(assessment_id: str) -> Path | None:
     """Path to generated target architecture PNG, if it exists."""
-    try:
-        uuid.UUID(assessment_id)
-    except ValueError:
+    if not _UUID_RE.match(assessment_id):
         return None
     root = Path(__file__).resolve().parent.parent.parent.parent
     p = root / "data" / "assessment_diagrams" / assessment_id / "target_architecture.png"


### PR DESCRIPTION
## Summary
After #125 merged, I checked the code-scanning API and all 14 `py/path-injection` alerts were still open (only the stack-trace-exposure one closed). Root cause: CodeQL's `py/path-injection` taint tracker doesn't recognize `uuid.UUID(assessment_id)` raising `ValueError` as a sanitizer on the string itself — it needs an explicit regex-match + early-return/raise pattern to treat the value as clean.

Swapped all 3 validators (`assessment.py`, `diagram_export.py`, `report_docx.py`) from `uuid.UUID()` try/except to a compiled UUID regex `fullmatch`-style check. Same validation semantics, functionally equivalent — just expressed in the idiom the static analyzer's dataflow model recognizes.

## Test plan
- [x] `PYTHONPATH=. pytest tests/ -v` — 80 passed, 1 pre-existing unrelated failure (mermaid.ink 403)
- [ ] Confirm via code-scanning API after this merges to `main` that all 14 alerts close