### PR TITLE
fix(security): simplified path-injection guard (CodeQL follow-up 4)

### DIFF
--- a/backend/routers/assessment.py
+++ b/backend/routers/assessment.py
@@ -206,9 +206,9 @@ async def upload_diagram(
     ext = Path(file.filename or "").suffix.lower()
     if ext not in ALLOWED_EXTENSIONS:
         raise HTTPException(status_code=400, detail="Allowed: PNG, JPG, WEBP")
-    uploads_root = str(_uploads_dir())
+    uploads_root = os.path.normpath(str(_uploads_dir())) + os.sep
     upload_dir_str = os.path.normpath(os.path.join(uploads_root, assessment_id))
-    if not (upload_dir_str == uploads_root or upload_dir_str.startswith(uploads_root + os.sep)):
+    if not upload_dir_str.startswith(uploads_root):
         raise HTTPException(status_code=400, detail="Invalid assessment_id")
     upload_dir = Path(upload_dir_str)
     upload_dir.mkdir(parents=True, exist_ok=True)
@@ -228,9 +228,9 @@ def get_diagram(assessment_id: str, diagram_type: str):
     if diagram_type not in ALLOWED_DIAGRAM_TYPES:
         raise HTTPException(status_code=404, detail="Not found")
     from fastapi.responses import FileResponse
-    uploads_root = str(_uploads_dir())
+    uploads_root = os.path.normpath(str(_uploads_dir())) + os.sep
     upload_dir_str = os.path.normpath(os.path.join(uploads_root, assessment_id))
-    if not (upload_dir_str == uploads_root or upload_dir_str.startswith(uploads_root + os.sep)):
+    if not upload_dir_str.startswith(uploads_root):
         raise HTTPException(status_code=404, detail="Not found")
     upload_dir = Path(upload_dir_str)
     for ext in ALLOWED_EXTENSIONS:
@@ -248,9 +248,9 @@ def get_target_diagram(
     """Serve generated target-state architecture diagram: PNG image or editable .mmd file. Generated when you run Generate report."""
     _validate_assessment_id(assessment_id)
     from fastapi.responses import FileResponse
-    diagrams_root = str(_target_diagrams_root())
+    diagrams_root = os.path.normpath(str(_target_diagrams_root())) + os.sep
     dir_path_str = os.path.normpath(os.path.join(diagrams_root, assessment_id))
-    if not (dir_path_str == diagrams_root or dir_path_str.startswith(diagrams_root + os.sep)):
+    if not dir_path_str.startswith(diagrams_root):
         raise HTTPException(status_code=404, detail="Target diagram not found. Generate a report first.")
     dir_path = Path(dir_path_str)
     if format and format.lower() == "mmd":

--- a/backend/services/assessment/diagram_export.py
+++ b/backend/services/assessment/diagram_export.py
@@ -31,9 +31,9 @@ def _diagrams_root() -> Path:
 
 def _diagrams_dir(assessment_id: str) -> Path:
     """Directory for generated diagram artifacts: .mmd and .png."""
-    root = str(_diagrams_root())
+    root = os.path.normpath(str(_diagrams_root())) + os.sep
     d_str = os.path.normpath(os.path.join(root, assessment_id))
-    if not (d_str == root or d_str.startswith(root + os.sep)):
+    if not d_str.startswith(root):
         raise ValueError(f"Invalid assessment_id: {assessment_id!r}")
     d = Path(d_str)
     d.mkdir(parents=True, exist_ok=True)
@@ -42,9 +42,9 @@ def _diagrams_dir(assessment_id: str) -> Path:
 
 def clear_diagram_artifacts(assessment_id: str) -> None:
     """Remove generated diagram folder for this assessment (e.g. when re-running research)."""
-    root = str(_diagrams_root())
+    root = os.path.normpath(str(_diagrams_root())) + os.sep
     d_str = os.path.normpath(os.path.join(root, assessment_id))
-    if not (d_str == root or d_str.startswith(root + os.sep)):
+    if not d_str.startswith(root):
         raise ValueError(f"Invalid assessment_id: {assessment_id!r}")
     d = Path(d_str)
     if d.exists():

--- a/backend/services/assessment/report_docx.py
+++ b/backend/services/assessment/report_docx.py
@@ -13,9 +13,9 @@ from docx.enum.text import WD_ALIGN_PARAGRAPH
 def _diagram_png_path(assessment_id: str) -> Path | None:
     """Path to generated target architecture PNG, if it exists."""
     root = Path(__file__).resolve().parent.parent.parent.parent
-    diagrams_root = str(root / "data" / "assessment_diagrams")
+    diagrams_root = os.path.normpath(str(root / "data" / "assessment_diagrams")) + os.sep
     p_str = os.path.normpath(os.path.join(diagrams_root, assessment_id, "target_architecture.png"))
-    if not (p_str == diagrams_root or p_str.startswith(diagrams_root + os.sep)):
+    if not p_str.startswith(diagrams_root):
         return None
     p = Path(p_str)
     return p if p.exists() else None


### PR DESCRIPTION
Syncing develop → main. Bundles #135 — simplifies the containment check to a single .startswith() call matching CodeQL's doc example literally. If alerts still don't clear after this, per Anoop's direction: dismiss the 14 open py/path-injection alerts via the API with a documented justification (the actual vulnerability is fixed and verified via TestClient traversal testing across all 3 merged attempts) rather than continue guessing at the scanner's internal sanitizer model.