### PR TITLE
fix(security): containment check on final path (CodeQL follow-up 5)

### DIFF
--- a/backend/routers/assessment.py
+++ b/backend/routers/assessment.py
@@ -212,7 +212,10 @@ async def upload_diagram(
         raise HTTPException(status_code=400, detail="Invalid assessment_id")
     upload_dir = Path(upload_dir_str)
     upload_dir.mkdir(parents=True, exist_ok=True)
-    dest = upload_dir / f"{diagram_type}{ext}"
+    dest_str = os.path.normpath(os.path.join(upload_dir_str, f"{diagram_type}{ext}"))
+    if not dest_str.startswith(uploads_root):
+        raise HTTPException(status_code=400, detail="Invalid assessment_id")
+    dest = Path(dest_str)
     content = await file.read()
     if len(content) > 10 * 1024 * 1024:  # 10 MB
         raise HTTPException(status_code=400, detail="File too large (max 10 MB)")
@@ -232,9 +235,11 @@ def get_diagram(assessment_id: str, diagram_type: str):
     upload_dir_str = os.path.normpath(os.path.join(uploads_root, assessment_id))
     if not upload_dir_str.startswith(uploads_root):
         raise HTTPException(status_code=404, detail="Not found")
-    upload_dir = Path(upload_dir_str)
     for ext in ALLOWED_EXTENSIONS:
-        p = upload_dir / f"{diagram_type}{ext}"
+        p_str = os.path.normpath(os.path.join(upload_dir_str, f"{diagram_type}{ext}"))
+        if not p_str.startswith(uploads_root):
+            continue
+        p = Path(p_str)
         if p.exists():
             return FileResponse(p, media_type=f"image/{ext[1:]}")
     raise HTTPException(status_code=404, detail="Diagram not found")


### PR DESCRIPTION
## Summary
#135 cleared 11/14 alerts — confirmed the single `.startswith()` call is the pattern CodeQL's `py/path-injection` recognizes as a sanitizer. The remaining 3 (all in `assessment.py`) share a pattern: after the checked directory, a further variable-derived suffix (`f"{diagram_type}{ext}"`) gets appended before the sink, re-introducing unproven taint. `get_target_diagram` appends a fixed literal filename instead and fully cleared, confirming this theory.

Extended the same check to the final constructed path in `upload_diagram` (before `dest.write_bytes`) and `get_diagram` (before `p.exists()`/`FileResponse`).

## Test plan
- [x] `PYTHONPATH=. pytest tests/ -v` — 80 passed, 1 pre-existing unrelated failure
- [x] TestClient smoke test — upload→fetch round trip still works, traversal still rejected
- [ ] Confirm via code-scanning API after merge that this clears the final 3 alerts