### PR TITLE
fix(security): patch pypdf + postcss CVEs; pin react-router-dom to v6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,14 @@ updates:
         patterns:
           - "vite"
           - "@vitejs/*"
+    ignore:
+      # react-router-dom: pinned to v6. Every currently-published version carries
+      # at least one advisory, and none are reachable in our declarative
+      # BrowserRouter SPA (no SSR, no RSC/framework mode):
+      #   - v6.x: open redirect (moderate) — below our --audit-level=high gate.
+      #   - v7.12.0–8.2.0: RSC Mode CSRF Bypass (HIGH) — would FAIL the daily scan.
+      # The open-redirect fix (>7.17.0) only exists inside the RSC-CSRF range, so
+      # there is no clean version yet. Staying on v6 keeps the scan green.
+      # Revisit when a react-router release clears BOTH advisories (>8.2.0).
+      - dependency-name: "react-router-dom"
+        update-types: ["version-update:semver-major"]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,7 @@
       "devDependencies": {
         "@vitejs/plugin-react": "^6.0.1",
         "autoprefixer": "^10.4.17",
-        "postcss": "^8.5.11",
+        "postcss": "^8.5.19",
         "tailwindcss": "^3.4.1",
         "vite": "^8.0.16"
       }
@@ -1280,9 +1280,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -1383,9 +1383,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -1403,7 +1403,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@vitejs/plugin-react": "^6.0.1",
     "autoprefixer": "^10.4.17",
-    "postcss": "^8.5.11",
+    "postcss": "^8.5.19",
     "tailwindcss": "^3.4.1",
     "vite": "^8.0.16"
   }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2026.1.4
 pinecone==8.1.2
 python-dotenv==1.2.2
-pypdf==6.13.3
+pypdf==6.14.2
 python-docx==1.2.0
 openpyxl==3.1.5
 xlrd==2.0.2


### PR DESCRIPTION
## What & why

Resolves the failing **Daily Security Scan** and the open Dependabot alerts. Every item was assessed for *actual exploitability* — not just "newer version exists."

| Package | Change | Severity | Verdict |
|---|---|---|---|
| **pypdf** | 6.13.3 → **6.14.2** | Medium (4 CVEs) | ✅ **Real** — fixed |
| **postcss** | 8.5.11 → **8.5.19** | High | ✅ Clears the only High — fixed |
| **react-router-dom** | stays **6.30.4** (+ dependabot ignore) | Moderate | ⚠️ Not exploitable — pinned |

### pypdf — real fix
App parses **user-uploaded PDFs** in `backend/document_extractors.py` via `PdfReader`. CVEs are DoS-class (unbounded CPU on malformed xref, huge memory on bogus image dims). `6.14.0` wasn't enough — pip-audit's fresher DB flagged two more (fixed in 6.14.1/6.14.2), so bumped to **6.14.2**.

### postcss — trivial High clear
Build-time dep; the source-map path-traversal only bites on *untrusted* CSS (we process our own), so real risk ≈ nil — but it's the only High and the fix is a non-breaking patch. Cleared.

### react-router-dom — deliberately NOT upgraded
Deep-dived the advisories. **No published version is clean**, and none are reachable in our declarative `BrowserRouter` SPA (no SSR / RSC / framework mode):

| Version | Advisory | Sev | Daily scan (`--audit-level=high`) |
|---|---|---|---|
| **6.30.4 (kept)** | open redirect | moderate | ✅ passes (below gate) |
| 7.18.1 (Dependabot #141) | RSC Mode CSRF Bypass | **high** | ❌ **would fail** |

Open-redirect fix (`>7.17.0`) only exists *inside* the RSC-CSRF range (`7.12.0–8.2.0`), so there's no version that clears both until `>8.2.0` ships. Upgrading trades a non-exploitable moderate for a **CI-breaking** high. Added a documented `ignore` in `dependabot.yml` for the v7 major so it stops being re-proposed. Revisit when react-router clears both advisories.

## Verification
- `pip-audit -r requirements.txt` → **No known vulnerabilities**
- `npm audit --audit-level=high` → **exit 0** (2 non-exploitable moderates remain by design)
- `npm run build` → passes (Vite)
- `pytest` → **80/80** (1 unrelated `@external` mermaid.ink network probe fails on sandbox 403 — environmental, not code)

## Supersedes
- Dependabot **#148** (postcss) and **#141** (react-router v7) — closing those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)