### PR TITLE
fix(ci): only tag real CVEs as security (stop mislabeling version bumps)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,12 @@ updates:
       time: "09:00"
       timezone: "America/New_York"
     open-pull-requests-limit: 5
+    # Only "dependencies" here. The "security" label is applied automatically
+    # by .github/workflows/dependabot-labels.yml — but ONLY to genuine
+    # alert-driven security updates (those with a GHSA id), never to plain
+    # version bumps. This keeps the "security" tag meaningful.
     labels:
       - "dependencies"
-      - "security"
     commit-message:
       prefix: "chore(deps)"
     groups:
@@ -28,9 +31,12 @@ updates:
       time: "09:00"
       timezone: "America/New_York"
     open-pull-requests-limit: 5
+    # Only "dependencies" here. The "security" label is applied automatically
+    # by .github/workflows/dependabot-labels.yml — but ONLY to genuine
+    # alert-driven security updates (those with a GHSA id), never to plain
+    # version bumps. This keeps the "security" tag meaningful.
     labels:
       - "dependencies"
-      - "security"
     commit-message:
       prefix: "chore(deps)"
     groups:

--- a/.github/workflows/dependabot-labels.yml
+++ b/.github/workflows/dependabot-labels.yml
@@ -1,0 +1,42 @@
+name: Dependabot PR labels
+
+# Tag Dependabot PRs accurately:
+#   - Genuine, alert-driven security updates (Dependabot exposes a GHSA id for
+#     these) get the "security" label.
+#   - Plain scheduled version bumps stay "dependencies" only and never carry
+#     the "security" label.
+# This replaces the old blanket "security" label in dependabot.yml, which was
+# tagging every version bump as a security issue.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag real security updates
+        if: steps.meta.outputs.ghsa-id != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.html_url }}
+        run: gh pr edit "$PR" --add-label security
+
+      - name: Keep version-only bumps free of the security label
+        if: steps.meta.outputs.ghsa-id == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.html_url }}
+        run: gh pr edit "$PR" --remove-label security || true


### PR DESCRIPTION
## Problem
`dependabot.yml` blanket-applied the **`security`** label to *every* PR Dependabot opened. So plain version bumps (react 19, tailwind 4, fastapi, uvicorn…) all showed up tagged `security`, making the security surface look scary and unclear. None of them are CVEs — the only real open Dependabot alert is `pypdf` (already fixed).

## Fix
- **Remove `security`** from `dependabot.yml` default labels (both pip + npm). Version bumps now carry only `dependencies`.
- **Add `.github/workflows/dependabot-labels.yml`** — applies `security` *only* to genuine alert-driven security updates (PRs that carry a GHSA id, via `dependabot/fetch-metadata`), and removes it from version-only bumps.

Net: **the `security` label now means a real CVE, nothing else.**

Also stripped the stale `security` label from the 9 currently-open version-bump PRs (#140, #142, #151–#157).

🤖 Generated with [Claude Code](https://claude.com/claude-code)