### PR TITLE
release: accurate Dependabot labeling (security label = real CVEs only)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,12 @@ updates:
       time: "09:00"
       timezone: "America/New_York"
     open-pull-requests-limit: 5
+    # Only "dependencies" here. The "security" label is applied automatically
+    # by .github/workflows/dependabot-labels.yml — but ONLY to genuine
+    # alert-driven security updates (those with a GHSA id), never to plain
+    # version bumps. This keeps the "security" tag meaningful.
     labels:
       - "dependencies"
-      - "security"
     commit-message:
       prefix: "chore(deps)"
     groups:
@@ -28,9 +31,12 @@ updates:
       time: "09:00"
       timezone: "America/New_York"
     open-pull-requests-limit: 5
+    # Only "dependencies" here. The "security" label is applied automatically
+    # by .github/workflows/dependabot-labels.yml — but ONLY to genuine
+    # alert-driven security updates (those with a GHSA id), never to plain
+    # version bumps. This keeps the "security" tag meaningful.
     labels:
       - "dependencies"
-      - "security"
     commit-message:
       prefix: "chore(deps)"
     groups:

--- a/.github/workflows/dependabot-labels.yml
+++ b/.github/workflows/dependabot-labels.yml
@@ -1,0 +1,42 @@
+name: Dependabot PR labels
+
+# Tag Dependabot PRs accurately:
+#   - Genuine, alert-driven security updates (Dependabot exposes a GHSA id for
+#     these) get the "security" label.
+#   - Plain scheduled version bumps stay "dependencies" only and never carry
+#     the "security" label.
+# This replaces the old blanket "security" label in dependabot.yml, which was
+# tagging every version bump as a security issue.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag real security updates
+        if: steps.meta.outputs.ghsa-id != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.html_url }}
+        run: gh pr edit "$PR" --add-label security
+
+      - name: Keep version-only bumps free of the security label
+        if: steps.meta.outputs.ghsa-id == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.html_url }}
+        run: gh pr edit "$PR" --remove-label security || true


### PR DESCRIPTION
Promotes the Dependabot label-accuracy fix (#158) to `main` so it takes effect on the default branch.

- `dependabot.yml`: `security` removed from blanket labels
- new `dependabot-labels.yml` workflow: tags `security` only on real GHSA-backed security updates

No app code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)